### PR TITLE
dotCMS/core#22995 next.js starter: Add inline editing for block field

### DIFF
--- a/src/components/Editable.tsx
+++ b/src/components/Editable.tsx
@@ -4,17 +4,19 @@ import * as React from 'react'
 export type EditableProps = {
   element: React.ReactElement
   className?: string
-  mode: string
+  mode?: string
   field: string
   lang: string
   inode: string
-  onClick?: () => void
+  onClick?: (event?: any) => void
   href?: string
-  textColor?: string
+  textColor?: string,
+  contentType?: any,
+  editorContent?: any
 }
 
 export const Editable = ({ element, ...rest }: EditableProps) => {
-  const { mode, field, lang, inode, onClick } = rest
+  const { mode, field, lang, inode, onClick, contentType, editorContent } = rest;
   const {
     props: { children },
   } = element
@@ -27,12 +29,14 @@ export const Editable = ({ element, ...rest }: EditableProps) => {
         ((e: React.MouseEvent<HTMLElement, MouseEvent>) => {
           e.preventDefault()
           e.stopPropagation()
-          onClick()
+          onClick(e)
         }),
       'data-mode': mode || 'minimal',
       'data-field-name': field,
       'data-language': lang,
       'data-inode': inode,
+      ...(contentType && { 'data-content-type': contentType}),
+      ...(editorContent && { 'data-block-editor-content': editorContent }),
     },
     children
   )

--- a/src/components/dotCMS/pages/BlogDetail.tsx
+++ b/src/components/dotCMS/pages/BlogDetail.tsx
@@ -1,15 +1,31 @@
 // Internals
 import { SinglePageDetail, ContentBlocks } from '@/components'
 import { DotCMSDetailPageProps } from './type'
+import Editable from '../../Editable';
 
 export function BlogDetail({
   pageRender: { urlContentMap: data },
 }: DotCMSDetailPageProps) {
-  const { blogContent } = data
+  const { blogContent, contentType, languageId, inode,  } = data
+
+  const onClick = (event) => {
+    const customEvent = new CustomEvent('ng-event', {
+      detail: { name: 'edit-block-editor', data: event.target }
+    });
+    window.top.document.dispatchEvent(customEvent); 
+  }
 
   return (
     <SinglePageDetail {...data}>
-      <ContentBlocks content={blogContent.content} />
+        <Editable
+            contentType={contentType}
+            editorContent={JSON.stringify(blogContent)}
+            element={<div><ContentBlocks content={blogContent.content} /></div>}
+            field="blogContent"
+            inode={inode}
+            lang={languageId.toString()}
+            onClick={onClick}
+        />
     </SinglePageDetail>
   )
 }


### PR DESCRIPTION
**What we did:**

1. Allow inline editing for block field.